### PR TITLE
Allow configuration from code generator

### DIFF
--- a/python/transformer.py
+++ b/python/transformer.py
@@ -171,7 +171,13 @@ def callback(channel, method, properties, body):
 
 def transform_single_file(file_path, output_path, servicex=None):
     print("Transforming a single path: " + str(file_path) + " into " + output_path)
-    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 numevents=-1 dataset=' + str(file_path) + ' name=' + str(output_path).replace("_RA2AnalysisTree.root","") + ' run=True fork=False log=True 2> log.txt && pwd && ls -alh ./ && ls -alh /home/cmsusr/ && ls -alh /servicex/')
+
+    selection = ''
+    with open('/generated/config.txt', 'r') as sel_file:
+        selection = sel_file.readline()
+    selection_split = selection.split(';')
+
+    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py ' + selection_split[0] + ' dataset=' + str(file_path) + ' name=' + str(output_path).replace("_RA2AnalysisTree.root", "") + ' command=\"' + selection_split[1] + '\" 2> log.txt && pwd && ls -alh ./ && ls -alh /home/cmsusr/ && ls -alh /servicex/')
     reason_bad = None
     if r != 0:
         reason_bad = "Error return from transformer: " + str(r)


### PR DESCRIPTION
Update the transformer to use configuration input from the code generator. The request will use the 'selection' entry and look like:
```yaml
"selection": "test=0 scenario=Summer16 numevents=-1 run=True fork=False log=True;emerging=True nestedVectors=False splitLevel=99 threads=4"
```
The first part of the selection string, prior to the `;`, are the `unitTest.py` specific pieces of the configuration. The second part are the pieces which go inside the `command` option of `unitTest.py`. Eventually, we will remove the usage of `unitTest.py` in place of a more generic cmsRun command and configuration.