### PR TITLE
Update the GHA set-env mechanism

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Reset user on push
       if: github.event_name == 'push'
-      run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
+      run: echo "current_user=$(echo ${{ github.repository }} | sed -E 's|/.*||')" >> $GITHUB_ENV
     - name: Look at key environment variables
       run: echo -e "GITHUB_REF=${{ github.ref }}\nGITHUB_HEAD_REF=${{ github.head_ref }}\nGITHUB_BASE_REF=${{ github.base_ref }}\nGITHUB_ACTOR=${{ github.actor }}\nGITHUB_REPOSITORY=${{ github.repository }}\nGITHUB_SHA=${{ github.sha }}\nUSER=${{ env.current_user }}\nTREEMAKER_BRANCH=${{ env.treemaker_branch }}\nTIME=${{ steps.current-time.outputs.formattedTime }}"
     - name: Dump GitHub context
@@ -45,7 +45,7 @@ jobs:
     steps:
     - name: Reset user on push
       if: github.event_name == 'push'
-      run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
+      run: echo "current_user=$(echo ${{ github.repository }} | sed -E 's|/.*||')" >> $GITHUB_ENV
     - name: Build a Service-X compatible Docker image
       env:
         script_dir: /home/cmsuser/ServiceX-Transformer/scripts/


### PR DESCRIPTION
Update the GitHub actions set-env command to use the new environment files mechanism (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).